### PR TITLE
fix overlay of modal over logo in mobile modal

### DIFF
--- a/app/components/Navbar/Navbar.module.scss
+++ b/app/components/Navbar/Navbar.module.scss
@@ -98,7 +98,7 @@
     align-items: center;
     list-style: none;
     margin-bottom: 0;
-    margin-top: 5rem;
+    margin-top: 6.5rem;
     border-radius: 0.5em;
     padding-left: 1em;
     padding-right: 1em;


### PR DESCRIPTION
fix modal overflow over the logo when the burger menu was opened